### PR TITLE
Unit Types distinguished by composition instead of inheritance

### DIFF
--- a/KingdomsAndWarfare/Units/Aerial.py
+++ b/KingdomsAndWarfare/Units/Aerial.py
@@ -1,43 +1,37 @@
-from .Unit import Unit
+from . import UnitEnums
+from .UnitType import UnitType
 
+class Aerial(UnitType):
+    def level_up(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        attack = attack + 1
+        defense = defense + 1
+        morale = morale + 1
+        command = command + 2
+        if experience == UnitEnums.Experience.VETERAN:
+            attacks = attacks + 1
+        return attacks, attack, defense, morale, command
 
-class Aerial(Unit):
-    def __init__(self, name: str, description: str):
-        self.type = Unit.Type.AERIAL
-        super().__init__(name, description)
+    def level_down(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        attack = attack - 1
+        defense = defense - 1
+        morale = morale - 1
+        command = command - 2
+        if experience == UnitEnums.Experience.ELITE:
+            attacks = attacks - 1
+        return attacks, attack, defense, morale, command
 
-    def level_up(self) -> None:
-        self.attack = self.attack + 1
-        self.defense = self.defense + 1
-        self.morale = self.morale + 1
-        self.command = self.command + 2
-        if self.experience == Unit.Experience.VETERAN:
-            self.attacks = self.attacks + 1
-        super().level_up()
+    def upgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        """Upgrade a unit's equipment bonuses. This is usually done by spending gold."""
+        power = power + 1
+        toughness = toughness + 1
+        if equipment == UnitEnums.Equipment.HEAVY:
+            damage = damage + 1
+        return power, toughness, damage
 
-    def level_down(self) -> None:
-        self.attack = self.attack - 1
-        self.defense = self.defense - 1
-        self.morale = self.morale - 1
-        self.command = self.command - 2
-        if self.experience == Unit.Experience.ELITE:
-            self.attacks = self.attacks - 1
-        super().level_down()
-
-    def upgrade(self) -> None:
-        """Upgrade a unit's equipment bonuses. This is usually done by spending gold.
-        Throws a CannotUpgradeError if trying to upgrade past Super Heavy equipment."""
-        self.power = self.power + 1
-        self.toughness = self.toughness + 1
-        if self.equipment == Unit.Equipment.HEAVY:
-            self.damage = self.damage + 1
-        super().upgrade()
-
-    def downgrade(self) -> None:
-        """Downgrade a unit's equipment bonuses. This is usualy the 'undo' function for upgrading.
-        Throws a CannotUpgradeError if trying to downgrade past Light equipment."""
-        self.power = self.power - 1
-        self.toughness = self.toughness - 1
-        if self.equipment == Unit.Equipment.SUPER_HEAVY:
-            self.damage = self.damage - 1
-        super().downgrade()
+    def downgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        """Downgrade a unit's equipment bonuses. This is usualy the 'undo' function for upgrading."""
+        power = power - 1
+        toughness = toughness - 1
+        if equipment == UnitEnums.Equipment.SUPER_HEAVY:
+            damage = damage - 1
+        return power, toughness, damage

--- a/KingdomsAndWarfare/Units/Artillery.py
+++ b/KingdomsAndWarfare/Units/Artillery.py
@@ -1,39 +1,33 @@
-from .Unit import Unit
+from . import UnitEnums
+from .UnitType import UnitType
 
+class Artillery(UnitType):
+    def level_up(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        attack = attack + 2
+        defense = defense + 1
+        morale = morale + 1
+        command = command + 1
+        if experience == UnitEnums.Experience.REGULAR:
+            attacks = attacks + 1
+        return attacks, attack, defense, morale, command
 
-class Artillery(Unit):
-    def __init__(self, name: str, description: str):
-        self.type = Unit.Type.ARTILLERY
-        super().__init__(name, description)
+    def level_down(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        attack = attack - 2
+        defense = defense - 1
+        morale = morale - 1
+        command = command - 1
+        if experience == UnitEnums.Experience.VETERAN:
+            attacks = attacks - 1
+        return attacks, attack, defense, morale, command
 
-    def level_up(self) -> None:
-        self.attack = self.attack + 2
-        self.defense = self.defense + 1
-        self.morale = self.morale + 1
-        self.command = self.command + 1
-        if self.experience == Unit.Experience.REGULAR:
-            self.attacks = self.attacks + 1
-        super().level_up()
+    def upgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        """Upgrade a unit's equipment bonuses. This is usually done by spending gold."""
+        power = power + 1
+        toughness = toughness + 1
+        return power, toughness, damage
 
-    def level_down(self) -> None:
-        self.attack = self.attack - 2
-        self.defense = self.defense - 1
-        self.morale = self.morale - 1
-        self.command = self.command - 1
-        if self.experience == Unit.Experience.VETERAN:
-            self.attacks = self.attacks - 1
-        super().level_down()
-
-    def upgrade(self) -> None:
-        """Upgrade a unit's equipment bonuses. This is usually done by spending gold.
-        Throws a CannotUpgradeError if trying to upgrade past Super Heavy equipment."""
-        self.power = self.power + 1
-        self.toughness = self.toughness + 1
-        super().upgrade()
-
-    def downgrade(self) -> None:
-        """Downgrade a unit's equipment bonuses. This is usualy the 'undo' function for upgrading.
-        Throws a CannotUpgradeError if trying to downgrade past Light equipment."""
-        self.power = self.power - 1
-        self.toughness = self.toughness - 1
-        super().downgrade()
+    def downgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        """Downgrade a unit's equipment bonuses. This is usualy the 'undo' function for upgrading."""
+        power = power - 1
+        toughness = toughness - 1
+        return power, toughness, damage

--- a/KingdomsAndWarfare/Units/Cavalry.py
+++ b/KingdomsAndWarfare/Units/Cavalry.py
@@ -1,43 +1,37 @@
-from .Unit import Unit
+from . import UnitEnums
+from .UnitType import UnitType
 
+class Cavalry(UnitType):
+    def level_up(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        attack = attack + 1
+        defense = defense + 1
+        morale = morale + 1
+        command = command + 2
+        if experience == UnitEnums.Experience.VETERAN:
+            attacks = attacks + 1
+        return attacks, attack, defense, morale, command
 
-class Cavalry(Unit):
-    def __init__(self, name: str, description: str):
-        self.type = Unit.Type.CAVALRY
-        super().__init__(name, description)
+    def level_down(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        attack = attack - 1
+        defense = defense - 1
+        morale = morale - 1
+        command = command - 2
+        if experience == UnitEnums.Experience.ELITE:
+            attacks = attacks - 1
+        return attacks, attack, defense, morale, command
 
-    def level_up(self) -> None:
-        self.attack = self.attack + 1
-        self.defense = self.defense + 1
-        self.morale = self.morale + 1
-        self.command = self.command + 2
-        if self.experience == Unit.Experience.VETERAN:
-            self.attacks = self.attacks + 1
-        super().level_up()
+    def upgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        """Upgrade a unit's equipment bonuses. This is usually done by spending gold."""
+        power = power + 1
+        toughness = toughness + 1
+        if equipment == UnitEnums.Equipment.HEAVY:
+            damage = damage + 1
+        return power, toughness, damage
 
-    def level_down(self) -> None:
-        self.attack = self.attack - 1
-        self.defense = self.defense - 1
-        self.morale = self.morale - 1
-        self.command = self.command - 2
-        if self.experience == Unit.Experience.ELITE:
-            self.attacks = self.attacks - 1
-        super().level_down()
-
-    def upgrade(self) -> None:
-        """Upgrade a unit's equipment bonuses. This is usually done by spending gold.
-        Throws a CannotUpgradeError if trying to upgrade past Super Heavy equipment."""
-        self.power = self.power + 1
-        self.toughness = self.toughness + 1
-        if self.equipment == Unit.Equipment.HEAVY:
-            self.damage = self.damage + 1
-        super().upgrade()
-
-    def downgrade(self) -> None:
-        """Downgrade a unit's equipment bonuses. This is usualy the 'undo' function for upgrading.
-        Throws a CannotUpgradeError if trying to downgrade past Light equipment."""
-        self.power = self.power - 1
-        self.toughness = self.toughness - 1
-        if self.equipment == Unit.Equipment.SUPER_HEAVY:
-            self.damage = self.damage - 1
-        super().downgrade()
+    def downgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        """Downgrade a unit's equipment bonuses. This is usualy the 'undo' function for upgrading."""
+        power = power - 1
+        toughness = toughness - 1
+        if equipment == UnitEnums.Equipment.SUPER_HEAVY:
+            damage = damage - 1
+        return power, toughness, damage

--- a/KingdomsAndWarfare/Units/Infantry.py
+++ b/KingdomsAndWarfare/Units/Infantry.py
@@ -1,45 +1,39 @@
-from .Unit import Unit
+from . import UnitEnums
+from .UnitType import UnitType
 
+class Infantry(UnitType):
+    def level_up(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        attack = attack + 1
+        defense = defense + 2
+        morale = morale + 2
+        if experience != UnitEnums.Experience.VETERAN:
+            command = command + 1
+        if experience == UnitEnums.Experience.VETERAN:
+            attacks = attacks + 1
+        return attacks, attack, defense, morale, command
 
-class Infantry(Unit):
-    def __init__(self, name: str, description: str):
-        self.type = Unit.Type.INFANTRY
-        super().__init__(name, description)
+    def level_down(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        attack = attack - 1
+        defense = defense - 2
+        morale = morale - 2
+        if experience != UnitEnums.Experience.ELITE:
+            command = command - 1
+        if experience == UnitEnums.Experience.ELITE:
+            attacks = attacks - 1
+        return attacks, attack, defense, morale, command
 
-    def level_up(self) -> None:
-        self.attack = self.attack + 1
-        self.defense = self.defense + 2
-        self.morale = self.morale + 2
-        if self.experience != Unit.Experience.VETERAN:
-            self.command = self.command + 1
-        if self.experience == Unit.Experience.VETERAN:
-            self.attacks = self.attacks + 1
-        super().level_up()
+    def upgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        """Upgrade a unit's equipment bonuses. This is usually done by spending gold."""
+        power = power + 2
+        toughness = toughness + 2
+        if equipment == UnitEnums.Equipment.HEAVY:
+            damage = damage + 1
+        return power, toughness, damage
 
-    def level_down(self) -> None:
-        self.attack = self.attack - 1
-        self.defense = self.defense - 2
-        self.morale = self.morale - 2
-        if self.experience != Unit.Experience.ELITE:
-            self.command = self.command - 1
-        if self.experience == Unit.Experience.ELITE:
-            self.attacks = self.attacks - 1
-        super().level_down()
-
-    def upgrade(self) -> None:
-        """Upgrade a unit's equipment bonuses. This is usually done by spending gold.
-        Throws a CannotUpgradeError if trying to upgrade past Super Heavy equipment."""
-        self.power = self.power + 2
-        self.toughness = self.toughness + 2
-        if self.equipment == Unit.Equipment.HEAVY:
-            self.damage = self.damage + 1
-        super().upgrade()
-
-    def downgrade(self) -> None:
-        """Downgrade a unit's equipment bonuses. This is usualy the 'undo' function for upgrading.
-        Throws a CannotUpgradeError if trying to downgrade past Light equipment."""
-        self.power = self.power - 2
-        self.toughness = self.toughness - 2
-        if self.equipment == Unit.Equipment.SUPER_HEAVY:
-            self.damage = self.damage - 1
-        super().downgrade()
+    def downgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        """Downgrade a unit's equipment bonuses. This is usualy the 'undo' function for upgrading."""
+        power = power - 2
+        toughness = toughness - 2
+        if equipment == UnitEnums.Equipment.SUPER_HEAVY:
+            damage = damage - 1
+        return power, toughness, damage

--- a/KingdomsAndWarfare/Units/Unit.py
+++ b/KingdomsAndWarfare/Units/Unit.py
@@ -1,11 +1,12 @@
 from enum import Enum
 from enum import IntEnum
 from pdb import set_trace
+from typing import Self
 
 from ..Traits import Trait
 
-
 class Unit:
+
     class Type(Enum):
         INFANTRY = 1
         ARTILLERY = 2
@@ -32,25 +33,42 @@ class Unit:
         HEAVY = 3
         SUPER_HEAVY = 4
 
-    def __init__(self, name: str, description: str):
+    def __init__(self, 
+                 name: str, 
+                 description: str = '', 
+                 ancestry: str = '', 
+                 experience: Experience = Experience.REGULAR,
+                 equipment: Equipment = Equipment.LIGHT,
+                 tier: Tier = Tier.I,
+                 size: int = 6,
+                 attacks: int = 1,
+                 damage: int = 1,
+                 attack: int = 0,
+                 defense: int = 10,
+                 power: int = 0,
+                 toughness: int = 10,
+                 morale: int = 0,
+                 command: int = 0,
+                 traits: list[str] = []):
         self.name = name
         self.description = description
-        self.battles = 0
-        self.traits = []
-        self.experience = Unit.Experience.REGULAR
-        self.equipment = Unit.Equipment.LIGHT
-        self.tier = Unit.Tier.I
-        self.attack = 0
-        self.defense = 10
-        self.power = 0
-        self.toughness = 10
-        self.morale = 0
-        self.command = 0
-        self.damage = 1
-        self.attacks = 1
-        self.ancestry = ""
+        self.battles = Unit.battles_from_xp(experience)
+        self.traits = traits
+        self.experience = experience
+        self.equipment = equipment
+        self.tier = tier
+        self.attack = attack
+        self.defense = defense
+        self.power = power
+        self.toughness = toughness
+        self.morale = morale
+        self.command = command
+        self.damage = damage
+        self.size = size
+        self.attacks = attacks
+        self.ancestry = ancestry
 
-    def __eq__(self, __value: "Unit") -> bool:
+    def __eq__(self, __value: Self) -> bool:
         matches = (
             self.name == __value.name
             and self.ancestry == __value.ancestry
@@ -59,6 +77,7 @@ class Unit:
             and self.battles == __value.battles
             and self.command == __value.command
             and self.damage == __value.damage
+            and self.size == __value.size
             and self.defense == __value.defense
             and self.description == __value.description
             and self.equipment == __value.equipment
@@ -76,7 +95,8 @@ class Unit:
         return f"{self.name}: [{self.experience}, {self.equipment}, {self.ancestry}, {self.Type}] \
             Tier: {self.tier}, \
                 ATK: {self.attack} DEF {self.defense} POW {self.power} TOU {self.toughness} \
-                MOR {self.morale} COM {self.command}. {self.attacks} attacks at {self.damage} each. Traits: {self.traits}."
+                MOR {self.morale} COM {self.command}. Size {self.size}. {self.attacks} attacks \
+                at {self.damage} each. Traits: {self.traits}."
 
     def add_trait(self, trait: Trait) -> None:
         """Adds a trait that gives a unit special abilities or weaknesses to the unit.
@@ -116,12 +136,7 @@ class Unit:
         if self.experience == Unit.Experience.SUPER_ELITE:
             raise CannotLevelUpError("Cannot level up a unit past Super-elite.")
         self.experience = Unit.Experience(self.experience + 1)
-        if self.experience == Unit.Experience.VETERAN:
-            self.battles = 1
-        elif self.experience == Unit.Experience.ELITE:
-            self.battles = 4
-        elif self.experience == Unit.Experience.SUPER_ELITE:
-            self.battles = 8
+        self.battles = Unit.battles_from_xp(self.experience)
 
     def level_down(self) -> None:
         """Reduces the experience of the unit one level. Usually as an 'undo' for
@@ -132,12 +147,7 @@ class Unit:
         if self.experience == Unit.Experience.REGULAR:
             raise CannotLevelUpError("Cannot lower level below regular.")
         self.experience = Unit.Experience(self.experience - 1)
-        if self.experience == Unit.Experience.REGULAR:
-            self.battles = 0
-        elif self.experience == Unit.Experience.VETERAN:
-            self.battles = 1
-        elif self.experience == Unit.Experience.ELITE:
-            self.battles = 4
+        self.battles = Unit.battles_from_xp(self.experience)
 
     def to_dict(self) -> dict:
         to_return = {
@@ -149,6 +159,7 @@ class Unit:
             "experience": self.experience.name,
             "equipment": self.equipment.name,
             "tier": self.tier,
+            "size": self.size,
             "attack": self.attack,
             "defense": self.defense,
             "power": self.power,
@@ -162,6 +173,18 @@ class Unit:
         for trait in self.traits:
             to_return["traits"].append(trait.to_dict())
         return to_return
+    
+    def battles_from_xp(experience: Experience) -> int:
+        if experience == Unit.Experience.REGULAR or experience == Unit.Experience.LEVIES:
+            return 0
+        elif experience == Unit.Experience.VETERAN:
+            return 1
+        elif experience == Unit.Experience.ELITE:
+            return 4
+        elif experience == Unit.Experience.SUPER_ELITE:
+            return 8
+        else:
+            raise NoSuchUnitExperienceError("Invalid unit experience detected: " + str(experience))
 
 
 class CannotUpgradeError(Exception):

--- a/KingdomsAndWarfare/Units/UnitEnums.py
+++ b/KingdomsAndWarfare/Units/UnitEnums.py
@@ -1,12 +1,6 @@
 from enum import Enum
 from enum import IntEnum
 
-class Type(Enum):
-    INFANTRY = 1
-    ARTILLERY = 2
-    CAVALRY = 3
-    AERIAL = 4
-
 class Tier(IntEnum):
     I = 1
     II = 2

--- a/KingdomsAndWarfare/Units/UnitEnums.py
+++ b/KingdomsAndWarfare/Units/UnitEnums.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from enum import IntEnum
+
+class Type(Enum):
+    INFANTRY = 1
+    ARTILLERY = 2
+    CAVALRY = 3
+    AERIAL = 4
+
+class Tier(IntEnum):
+    I = 1
+    II = 2
+    III = 3
+    IV = 4
+    V = 5
+
+class Experience(IntEnum):
+    LEVIES = 1
+    REGULAR = 2
+    VETERAN = 3
+    ELITE = 4
+    SUPER_ELITE = 5
+
+class Equipment(IntEnum):
+    LIGHT = 1
+    MEDIUM = 2
+    HEAVY = 3
+    SUPER_HEAVY = 4

--- a/KingdomsAndWarfare/Units/UnitFactory.py
+++ b/KingdomsAndWarfare/Units/UnitFactory.py
@@ -1,11 +1,9 @@
 import pdb
 
 from ..Traits.Trait import Trait
-from .Aerial import Aerial
-from .Artillery import Artillery
-from .Cavalry import Cavalry
-from .Infantry import Infantry
 from .Unit import Unit
+from .UnitType import UnitType
+from . import UnitEnums
 
 
 def unit_from_dict(new_unit_dict: dict) -> "Unit":
@@ -13,14 +11,14 @@ def unit_from_dict(new_unit_dict: dict) -> "Unit":
     new_type = parse_type(new_unit_dict["type"])
     new_name = new_unit_dict["name"]
     new_description = new_unit_dict["description"]
-    if new_type == Unit.Type.INFANTRY:
-        new_unit = Infantry(new_name, new_description)
-    elif new_type == Unit.Type.CAVALRY:
-        new_unit = Cavalry(new_name, new_description)
-    elif new_type == Unit.Type.ARTILLERY:
-        new_unit = Artillery(new_name, new_description)
-    elif new_type == Unit.Type.AERIAL:
-        new_unit = Aerial(new_name, new_description)
+    if new_type == UnitEnums.Type.INFANTRY:
+        new_unit = Unit(new_name, UnitEnums.Type.INFANTRY, new_description)
+    elif new_type == UnitEnums.Type.CAVALRY:
+        new_unit = Unit(new_name, UnitEnums.Type.CAVALRY, new_description)
+    elif new_type == UnitEnums.Type.ARTILLERY:
+        new_unit = Unit(new_name, UnitEnums.Type.ARTILLERY, new_description)
+    elif new_type == UnitEnums.Type.AERIAL:
+        new_unit = Unit(new_name, UnitEnums.Type.AERIAL, new_description)
     else:
         raise NoSuchUnitTypeError(
             f"Could not instantiate unit type of {new_type}. \
@@ -46,40 +44,40 @@ def unit_from_dict(new_unit_dict: dict) -> "Unit":
     return new_unit
 
 
-def parse_type(type_string: str) -> Unit.Type:
+def parse_type(type_string: str) -> UnitType:
     if len(type_string) == 1:
         type_int = int(type_string)
         if type_int < 1 or type_int > 4:
             raise NoSuchUnitTypeError()
-        return Unit.Type(type_int)
+        return UnitEnums.Type(type_int)
     type_name = type_string.upper().replace("TYPE.", "")
     if type_name not in ["INFANTRY", "ARTILLERY", "AERIAL", "CAVALRY"]:
         raise NoSuchUnitTypeError()
-    return Unit.Type[type_name]
+    return UnitEnums.Type[type_name]
 
 
-def parse_experience(experience_string: str) -> Unit.Experience:
+def parse_experience(experience_string: str) -> UnitEnums.Experience:
     if len(experience_string) == 1:
         type_int = int(experience_string)
         if type_int < 1 or type_int > 5:
             raise NoSuchUnitExperienceError()
-        return Unit.Experience(type_int)
+        return UnitEnums.Experience(type_int)
     type_name = experience_string.upper().replace("EXPERIENCE.", "")
     if type_name not in ["LEVIES", "REGULAR", "VETERAN", "ELITE", "SUPER_ELITE"]:
         raise NoSuchUnitExperienceError()
-    return Unit.Experience[type_name]
+    return UnitEnums.Experience[type_name]
 
 
-def parse_equipment(equipment_string: str) -> Unit.Equipment:
+def parse_equipment(equipment_string: str) -> UnitEnums.Equipment:
     if len(equipment_string) == 1:
         type_int = int(equipment_string)
         if type_int < 1 or type_int > 4:
             raise NoSuchUnitEquipmentError()
-        return Unit.Equipment(type_int)
+        return UnitEnums.Equipment(type_int)
     type_name = equipment_string.upper().replace("EQUIPMENT.", "")
     if type_name not in ["LIGHT", "MEDIUM", "HEAVY", "SUPER_HEAVY"]:
         raise NoSuchUnitEquipmentError()
-    return Unit.Equipment[type_name]
+    return UnitEnums.Equipment[type_name]
 
 
 class UnitError(Exception):

--- a/KingdomsAndWarfare/Units/UnitFactory.py
+++ b/KingdomsAndWarfare/Units/UnitFactory.py
@@ -1,6 +1,10 @@
 import pdb
 
 from ..Traits.Trait import Trait
+from .Aerial import Aerial
+from .Artillery import Artillery
+from .Cavalry import Cavalry
+from .Infantry import Infantry
 from .Unit import Unit
 from .UnitType import UnitType
 from . import UnitEnums
@@ -11,19 +15,7 @@ def unit_from_dict(new_unit_dict: dict) -> "Unit":
     new_type = parse_type(new_unit_dict["type"])
     new_name = new_unit_dict["name"]
     new_description = new_unit_dict["description"]
-    if new_type == UnitEnums.Type.INFANTRY:
-        new_unit = Unit(new_name, UnitEnums.Type.INFANTRY, new_description)
-    elif new_type == UnitEnums.Type.CAVALRY:
-        new_unit = Unit(new_name, UnitEnums.Type.CAVALRY, new_description)
-    elif new_type == UnitEnums.Type.ARTILLERY:
-        new_unit = Unit(new_name, UnitEnums.Type.ARTILLERY, new_description)
-    elif new_type == UnitEnums.Type.AERIAL:
-        new_unit = Unit(new_name, UnitEnums.Type.AERIAL, new_description)
-    else:
-        raise NoSuchUnitTypeError(
-            f"Could not instantiate unit type of {new_type}. \
-                                       Expected one of [Infantry, Cavalry, Artillery, Aerial]."
-        )
+    new_unit = Unit(new_name, new_type, new_description)
     new_unit.battles = int(new_unit_dict["battles"])
     new_unit.traits = []
     for trait_dict in new_unit_dict["traits"]:
@@ -45,15 +37,19 @@ def unit_from_dict(new_unit_dict: dict) -> "Unit":
 
 
 def parse_type(type_string: str) -> UnitType:
-    if len(type_string) == 1:
-        type_int = int(type_string)
-        if type_int < 1 or type_int > 4:
-            raise NoSuchUnitTypeError()
-        return UnitEnums.Type(type_int)
-    type_name = type_string.upper().replace("TYPE.", "")
-    if type_name not in ["INFANTRY", "ARTILLERY", "AERIAL", "CAVALRY"]:
-        raise NoSuchUnitTypeError()
-    return UnitEnums.Type[type_name]
+    if type_string == Aerial.__qualname__:
+        return Aerial
+    elif type_string == Artillery.__qualname__:
+        return Artillery
+    elif type_string == Cavalry.__qualname__:
+        return Cavalry
+    elif type_string == Infantry.__qualname__:
+        return Infantry
+    else:
+        raise NoSuchUnitTypeError(
+            f"Could not instantiate unit type of {type_string}. \
+                                       Expected one of [Infantry, Cavalry, Artillery, Aerial]."
+        )
 
 
 def parse_experience(experience_string: str) -> UnitEnums.Experience:

--- a/KingdomsAndWarfare/Units/UnitFactory.py
+++ b/KingdomsAndWarfare/Units/UnitFactory.py
@@ -35,6 +35,7 @@ def unit_from_dict(new_unit_dict: dict) -> "Unit":
     new_unit.tier = new_unit_dict["tier"]
     new_unit.attack = int(new_unit_dict["attack"])
     new_unit.defense = int(new_unit_dict["defense"])
+    new_unit.size = int(new_unit_dict["size"])
     new_unit.power = int(new_unit_dict["power"])
     new_unit.toughness = int(new_unit_dict["toughness"])
     new_unit.morale = int(new_unit_dict["morale"])

--- a/KingdomsAndWarfare/Units/UnitType.py
+++ b/KingdomsAndWarfare/Units/UnitType.py
@@ -1,0 +1,20 @@
+from abc import ABCMeta, abstractmethod
+
+from . import UnitEnums
+
+class UnitType(metaclass = ABCMeta):
+    @abstractmethod
+    def level_up(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def level_down(experience: UnitEnums.Experience, attacks: int, attack: int, defense: int, morale: int, command: int) -> tuple[int, int, int, int, int]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def upgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def downgrade(equipment: UnitEnums.Equipment, power: int, toughness: int, damage: int) -> tuple[int, int, int]:
+        raise NotImplementedError()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="KingdomsAndWarfare",
-    version="0.2.4",
+    version="0.2.5",
     description="Kingdoms, Units, Unit Traits all for MCDM's excellent expansion for D&D",
     packages=[
         "KingdomsAndWarfare.Traits",

--- a/test/test_aerial_unit_class.py
+++ b/test/test_aerial_unit_class.py
@@ -1,18 +1,19 @@
 import pytest
 
+from ..KingdomsAndWarfare.Units.Aerial import Aerial
 from ..KingdomsAndWarfare.Units.Unit import Unit
 from ..KingdomsAndWarfare.Units import UnitEnums
 
 
 def test_aerial():
-    splonks_aerial = Unit("splonks aerial", UnitEnums.Type.AERIAL, "splonks_aerial riding rockinghorses.")
+    splonks_aerial = Unit("splonks aerial", Aerial, "splonks_aerial riding rockinghorses.")
     assert splonks_aerial.name == "splonks aerial"
     assert splonks_aerial.experience == UnitEnums.Experience.REGULAR
-    assert splonks_aerial.unit_type == UnitEnums.Type.AERIAL
+    assert splonks_aerial.unit_type == Aerial
 
 
 def test_aerial_level_up():
-    teddy_bear_aerial = Unit("Teddy Bear aerial", UnitEnums.Type.AERIAL, "Teddy Bears riding rockinghorses.")
+    teddy_bear_aerial = Unit("Teddy Bear aerial", Aerial, "Teddy Bears riding rockinghorses.")
     teddy_bear_aerial.attack = 0
     teddy_bear_aerial.defense = 10
     teddy_bear_aerial.morale = 0
@@ -44,7 +45,7 @@ def test_aerial_level_up():
 
 
 def test_aerial_upgrade():
-    test_aerial = Unit("Test", UnitEnums.Type.AERIAL, "Armed with personality tests.")
+    test_aerial = Unit("Test", Aerial, "Armed with personality tests.")
     test_aerial.power = 0
     test_aerial.toughness = 10
     assert test_aerial.equipment == UnitEnums.Equipment.LIGHT

--- a/test/test_aerial_unit_class.py
+++ b/test/test_aerial_unit_class.py
@@ -1,23 +1,23 @@
 import pytest
 
-from ..KingdomsAndWarfare.Units.Aerial import Aerial
 from ..KingdomsAndWarfare.Units.Unit import Unit
+from ..KingdomsAndWarfare.Units import UnitEnums
 
 
 def test_aerial():
-    splonks_aerial = Aerial("splonks aerial", "splonks_aerial riding rockinghorses.")
+    splonks_aerial = Unit("splonks aerial", UnitEnums.Type.AERIAL, "splonks_aerial riding rockinghorses.")
     assert splonks_aerial.name == "splonks aerial"
-    assert splonks_aerial.experience == Unit.Experience.REGULAR
-    assert splonks_aerial.type == Unit.Type.AERIAL
+    assert splonks_aerial.experience == UnitEnums.Experience.REGULAR
+    assert splonks_aerial.unit_type == UnitEnums.Type.AERIAL
 
 
 def test_aerial_level_up():
-    teddy_bear_aerial = Aerial("Teddy Bear aerial", "Teddy Bears riding rockinghorses.")
+    teddy_bear_aerial = Unit("Teddy Bear aerial", UnitEnums.Type.AERIAL, "Teddy Bears riding rockinghorses.")
     teddy_bear_aerial.attack = 0
     teddy_bear_aerial.defense = 10
     teddy_bear_aerial.morale = 0
     teddy_bear_aerial.command = 0
-    assert teddy_bear_aerial.experience == Unit.Experience.REGULAR
+    assert teddy_bear_aerial.experience == UnitEnums.Experience.REGULAR
     teddy_bear_aerial.level_up()
     # assert stats were changed by level up correctly
     # magic numbers provided by table from MCDM K&W page 99
@@ -26,40 +26,40 @@ def test_aerial_level_up():
     assert teddy_bear_aerial.defense == 11
     assert teddy_bear_aerial.morale == 1
     assert teddy_bear_aerial.command == 2
-    assert teddy_bear_aerial.experience == Unit.Experience.VETERAN
+    assert teddy_bear_aerial.experience == UnitEnums.Experience.VETERAN
     teddy_bear_aerial.level_up()
     assert teddy_bear_aerial.attacks == 2
     assert teddy_bear_aerial.attack == 2
     assert teddy_bear_aerial.defense == 12
     assert teddy_bear_aerial.morale == 2
     assert teddy_bear_aerial.command == 4
-    assert teddy_bear_aerial.experience == Unit.Experience.ELITE
+    assert teddy_bear_aerial.experience == UnitEnums.Experience.ELITE
     teddy_bear_aerial.level_up()
     assert teddy_bear_aerial.attacks == 2
     assert teddy_bear_aerial.attack == 3
     assert teddy_bear_aerial.defense == 13
     assert teddy_bear_aerial.morale == 3
     assert teddy_bear_aerial.command == 6
-    assert teddy_bear_aerial.experience == Unit.Experience.SUPER_ELITE
+    assert teddy_bear_aerial.experience == UnitEnums.Experience.SUPER_ELITE
 
 
 def test_aerial_upgrade():
-    test_aerial = Aerial("Test", "Armed with personality tests.")
+    test_aerial = Unit("Test", UnitEnums.Type.AERIAL, "Armed with personality tests.")
     test_aerial.power = 0
     test_aerial.toughness = 10
-    assert test_aerial.equipment == Unit.Equipment.LIGHT
+    assert test_aerial.equipment == UnitEnums.Equipment.LIGHT
     test_aerial.upgrade()
-    assert test_aerial.equipment == Unit.Equipment.MEDIUM
+    assert test_aerial.equipment == UnitEnums.Equipment.MEDIUM
     assert test_aerial.power == 1
     assert test_aerial.toughness == 11
     assert test_aerial.damage == 1
     test_aerial.upgrade()
-    assert test_aerial.equipment == Unit.Equipment.HEAVY
+    assert test_aerial.equipment == UnitEnums.Equipment.HEAVY
     assert test_aerial.power == 2
     assert test_aerial.toughness == 12
     assert test_aerial.damage == 1
     test_aerial.upgrade()
-    assert test_aerial.equipment == Unit.Equipment.SUPER_HEAVY
+    assert test_aerial.equipment == UnitEnums.Equipment.SUPER_HEAVY
     assert test_aerial.power == 3
     assert test_aerial.toughness == 13
     assert test_aerial.damage == 2

--- a/test/test_artillery_unit_class.py
+++ b/test/test_artillery_unit_class.py
@@ -1,25 +1,25 @@
 import pytest
 
-from ..KingdomsAndWarfare.Units.Artillery import Artillery
 from ..KingdomsAndWarfare.Units.Unit import Unit
+from ..KingdomsAndWarfare.Units import UnitEnums
 
 
 def test_artillery():
-    splonks_artillery = Artillery(
-        "splonks_artillery artillery", "splonks_artillery with bottle rockets"
+    splonks_artillery = Unit(
+        "splonks_artillery artillery", UnitEnums.Type.ARTILLERY, "splonks_artillery with bottle rockets"
     )
     assert splonks_artillery.name == "splonks_artillery artillery"
-    assert splonks_artillery.experience == Unit.Experience.REGULAR
-    assert splonks_artillery.type == Unit.Type.ARTILLERY
+    assert splonks_artillery.experience == UnitEnums.Experience.REGULAR
+    assert splonks_artillery.unit_type == UnitEnums.Type.ARTILLERY
 
 
 def test_artillery_level_up():
-    teddy_bear_artillery = Artillery("Teddy Bear artillery", "Teddy Bears with Toy Swords")
+    teddy_bear_artillery = Unit("Teddy Bear artillery", UnitEnums.Type.ARTILLERY, "Teddy Bears with Toy Swords")
     teddy_bear_artillery.attack = 0
     teddy_bear_artillery.defense = 10
     teddy_bear_artillery.morale = 0
     teddy_bear_artillery.command = 0
-    assert teddy_bear_artillery.experience == Unit.Experience.REGULAR
+    assert teddy_bear_artillery.experience == UnitEnums.Experience.REGULAR
     teddy_bear_artillery.level_up()
     # assert stats were changed by level up correctly
     # magic numbers provided by table from MCDM K&W page 99
@@ -28,37 +28,37 @@ def test_artillery_level_up():
     assert teddy_bear_artillery.defense == 11
     assert teddy_bear_artillery.morale == 1
     assert teddy_bear_artillery.command == 1
-    assert teddy_bear_artillery.experience == Unit.Experience.VETERAN
+    assert teddy_bear_artillery.experience == UnitEnums.Experience.VETERAN
     teddy_bear_artillery.level_up()
     assert teddy_bear_artillery.attacks == 2
     assert teddy_bear_artillery.attack == 4
     assert teddy_bear_artillery.defense == 12
     assert teddy_bear_artillery.morale == 2
     assert teddy_bear_artillery.command == 2
-    assert teddy_bear_artillery.experience == Unit.Experience.ELITE
+    assert teddy_bear_artillery.experience == UnitEnums.Experience.ELITE
     teddy_bear_artillery.level_up()
     assert teddy_bear_artillery.attacks == 2
     assert teddy_bear_artillery.attack == 6
     assert teddy_bear_artillery.defense == 13
     assert teddy_bear_artillery.morale == 3
     assert teddy_bear_artillery.command == 3
-    assert teddy_bear_artillery.experience == Unit.Experience.SUPER_ELITE
+    assert teddy_bear_artillery.experience == UnitEnums.Experience.SUPER_ELITE
 
 
 def test_artillery_upgrade():
-    test_artillery = Artillery("Test", "Armed with personality tests.")
+    test_artillery = Unit("Test", UnitEnums.Type.ARTILLERY, "Armed with personality tests.")
     test_artillery.power = 0
     test_artillery.toughness = 10
-    assert test_artillery.equipment == Unit.Equipment.LIGHT
+    assert test_artillery.equipment == UnitEnums.Equipment.LIGHT
     test_artillery.upgrade()
-    assert test_artillery.equipment == Unit.Equipment.MEDIUM
+    assert test_artillery.equipment == UnitEnums.Equipment.MEDIUM
     assert test_artillery.power == 1
     assert test_artillery.toughness == 11
     test_artillery.upgrade()
-    assert test_artillery.equipment == Unit.Equipment.HEAVY
+    assert test_artillery.equipment == UnitEnums.Equipment.HEAVY
     assert test_artillery.power == 2
     assert test_artillery.toughness == 12
     test_artillery.upgrade()
-    assert test_artillery.equipment == Unit.Equipment.SUPER_HEAVY
+    assert test_artillery.equipment == UnitEnums.Equipment.SUPER_HEAVY
     assert test_artillery.power == 3
     assert test_artillery.toughness == 13

--- a/test/test_artillery_unit_class.py
+++ b/test/test_artillery_unit_class.py
@@ -1,20 +1,21 @@
 import pytest
 
+from ..KingdomsAndWarfare.Units.Artillery import Artillery
 from ..KingdomsAndWarfare.Units.Unit import Unit
 from ..KingdomsAndWarfare.Units import UnitEnums
 
 
 def test_artillery():
     splonks_artillery = Unit(
-        "splonks_artillery artillery", UnitEnums.Type.ARTILLERY, "splonks_artillery with bottle rockets"
+        "splonks_artillery artillery", Artillery, "splonks_artillery with bottle rockets"
     )
     assert splonks_artillery.name == "splonks_artillery artillery"
     assert splonks_artillery.experience == UnitEnums.Experience.REGULAR
-    assert splonks_artillery.unit_type == UnitEnums.Type.ARTILLERY
+    assert splonks_artillery.unit_type == Artillery
 
 
 def test_artillery_level_up():
-    teddy_bear_artillery = Unit("Teddy Bear artillery", UnitEnums.Type.ARTILLERY, "Teddy Bears with Toy Swords")
+    teddy_bear_artillery = Unit("Teddy Bear artillery", Artillery, "Teddy Bears with Toy Swords")
     teddy_bear_artillery.attack = 0
     teddy_bear_artillery.defense = 10
     teddy_bear_artillery.morale = 0
@@ -46,7 +47,7 @@ def test_artillery_level_up():
 
 
 def test_artillery_upgrade():
-    test_artillery = Unit("Test", UnitEnums.Type.ARTILLERY, "Armed with personality tests.")
+    test_artillery = Unit("Test", Artillery, "Armed with personality tests.")
     test_artillery.power = 0
     test_artillery.toughness = 10
     assert test_artillery.equipment == UnitEnums.Equipment.LIGHT

--- a/test/test_cavalry_unit_class.py
+++ b/test/test_cavalry_unit_class.py
@@ -1,18 +1,19 @@
 import pytest
 
+from ..KingdomsAndWarfare.Units.Cavalry import Cavalry
 from ..KingdomsAndWarfare.Units.Unit import Unit
 from ..KingdomsAndWarfare.Units import UnitEnums
 
 
 def test_cavalry():
-    splonks_cavalry = Unit("splonks cavalry", UnitEnums.Type.CAVALRY, "splonks_cavalry riding rockinghorses.")
+    splonks_cavalry = Unit("splonks cavalry", Cavalry, "splonks_cavalry riding rockinghorses.")
     assert splonks_cavalry.name == "splonks cavalry"
     assert splonks_cavalry.experience == UnitEnums.Experience.REGULAR
-    assert splonks_cavalry.unit_type == UnitEnums.Type.CAVALRY
+    assert splonks_cavalry.unit_type == Cavalry
 
 
 def test_cavalry_level_up():
-    teddy_bear_cavalry = Unit("Teddy Bear cavalry", UnitEnums.Type.CAVALRY, "Teddy Bears riding rockinghorses.")
+    teddy_bear_cavalry = Unit("Teddy Bear cavalry", Cavalry, "Teddy Bears riding rockinghorses.")
     teddy_bear_cavalry.attack = 0
     teddy_bear_cavalry.defense = 10
     teddy_bear_cavalry.morale = 0
@@ -44,7 +45,7 @@ def test_cavalry_level_up():
 
 
 def test_cavalry_upgrade():
-    test_cavalry = Unit("Test", UnitEnums.Type.CAVALRY, "Armed with personality tests.")
+    test_cavalry = Unit("Test", Cavalry, "Armed with personality tests.")
     test_cavalry.power = 0
     test_cavalry.toughness = 10
     assert test_cavalry.equipment == UnitEnums.Equipment.LIGHT

--- a/test/test_cavalry_unit_class.py
+++ b/test/test_cavalry_unit_class.py
@@ -1,23 +1,23 @@
 import pytest
 
-from ..KingdomsAndWarfare.Units.Cavalry import Cavalry
 from ..KingdomsAndWarfare.Units.Unit import Unit
+from ..KingdomsAndWarfare.Units import UnitEnums
 
 
 def test_cavalry():
-    splonks_cavalry = Cavalry("splonks cavalry", "splonks_cavalry riding rockinghorses.")
+    splonks_cavalry = Unit("splonks cavalry", UnitEnums.Type.CAVALRY, "splonks_cavalry riding rockinghorses.")
     assert splonks_cavalry.name == "splonks cavalry"
-    assert splonks_cavalry.experience == Unit.Experience.REGULAR
-    assert splonks_cavalry.type == Unit.Type.CAVALRY
+    assert splonks_cavalry.experience == UnitEnums.Experience.REGULAR
+    assert splonks_cavalry.unit_type == UnitEnums.Type.CAVALRY
 
 
 def test_cavalry_level_up():
-    teddy_bear_cavalry = Cavalry("Teddy Bear cavalry", "Teddy Bears riding rockinghorses.")
+    teddy_bear_cavalry = Unit("Teddy Bear cavalry", UnitEnums.Type.CAVALRY, "Teddy Bears riding rockinghorses.")
     teddy_bear_cavalry.attack = 0
     teddy_bear_cavalry.defense = 10
     teddy_bear_cavalry.morale = 0
     teddy_bear_cavalry.command = 0
-    assert teddy_bear_cavalry.experience == Unit.Experience.REGULAR
+    assert teddy_bear_cavalry.experience == UnitEnums.Experience.REGULAR
     teddy_bear_cavalry.level_up()
     # assert stats were changed by level up correctly
     # magic numbers provided by table from MCDM K&W page 99
@@ -26,40 +26,40 @@ def test_cavalry_level_up():
     assert teddy_bear_cavalry.defense == 11
     assert teddy_bear_cavalry.morale == 1
     assert teddy_bear_cavalry.command == 2
-    assert teddy_bear_cavalry.experience == Unit.Experience.VETERAN
+    assert teddy_bear_cavalry.experience == UnitEnums.Experience.VETERAN
     teddy_bear_cavalry.level_up()
     assert teddy_bear_cavalry.attacks == 2
     assert teddy_bear_cavalry.attack == 2
     assert teddy_bear_cavalry.defense == 12
     assert teddy_bear_cavalry.morale == 2
     assert teddy_bear_cavalry.command == 4
-    assert teddy_bear_cavalry.experience == Unit.Experience.ELITE
+    assert teddy_bear_cavalry.experience == UnitEnums.Experience.ELITE
     teddy_bear_cavalry.level_up()
     assert teddy_bear_cavalry.attacks == 2
     assert teddy_bear_cavalry.attack == 3
     assert teddy_bear_cavalry.defense == 13
     assert teddy_bear_cavalry.morale == 3
     assert teddy_bear_cavalry.command == 6
-    assert teddy_bear_cavalry.experience == Unit.Experience.SUPER_ELITE
+    assert teddy_bear_cavalry.experience == UnitEnums.Experience.SUPER_ELITE
 
 
 def test_cavalry_upgrade():
-    test_cavalry = Cavalry("Test", "Armed with personality tests.")
+    test_cavalry = Unit("Test", UnitEnums.Type.CAVALRY, "Armed with personality tests.")
     test_cavalry.power = 0
     test_cavalry.toughness = 10
-    assert test_cavalry.equipment == Unit.Equipment.LIGHT
+    assert test_cavalry.equipment == UnitEnums.Equipment.LIGHT
     test_cavalry.upgrade()
-    assert test_cavalry.equipment == Unit.Equipment.MEDIUM
+    assert test_cavalry.equipment == UnitEnums.Equipment.MEDIUM
     assert test_cavalry.power == 1
     assert test_cavalry.toughness == 11
     assert test_cavalry.damage == 1
     test_cavalry.upgrade()
-    assert test_cavalry.equipment == Unit.Equipment.HEAVY
+    assert test_cavalry.equipment == UnitEnums.Equipment.HEAVY
     assert test_cavalry.power == 2
     assert test_cavalry.toughness == 12
     assert test_cavalry.damage == 1
     test_cavalry.upgrade()
-    assert test_cavalry.equipment == Unit.Equipment.SUPER_HEAVY
+    assert test_cavalry.equipment == UnitEnums.Equipment.SUPER_HEAVY
     assert test_cavalry.power == 3
     assert test_cavalry.toughness == 13
     assert test_cavalry.damage == 2

--- a/test/test_infantry_unit_class.py
+++ b/test/test_infantry_unit_class.py
@@ -1,23 +1,23 @@
 import pytest
 
-from ..KingdomsAndWarfare.Units.Infantry import Infantry
 from ..KingdomsAndWarfare.Units.Unit import Unit
+from ..KingdomsAndWarfare.Units import UnitEnums
 
 
 def test_infantry():
-    splonks_infantry = Infantry("splonks_infantry Infantry", "splonks_infantry with butterknives")
+    splonks_infantry = Unit("splonks_infantry Infantry", UnitEnums.Type.INFANTRY, "splonks_infantry with butterknives")
     assert splonks_infantry.name == "splonks_infantry Infantry"
-    assert splonks_infantry.experience == Unit.Experience.REGULAR
-    assert splonks_infantry.type == Unit.Type.INFANTRY
+    assert splonks_infantry.experience == UnitEnums.Experience.REGULAR
+    assert splonks_infantry.unit_type == UnitEnums.Type.INFANTRY
 
 
 def test_infantry_level_up():
-    teddy_bear_infantry = Infantry("Teddy Bear Infantry", "Teddy Bears with Toy Swords")
+    teddy_bear_infantry = Unit("Teddy Bear Infantry", UnitEnums.Type.INFANTRY, "Teddy Bears with Toy Swords")
     teddy_bear_infantry.attack = 0
     teddy_bear_infantry.defense = 10
     teddy_bear_infantry.morale = 0
     teddy_bear_infantry.command = 0
-    assert teddy_bear_infantry.experience == Unit.Experience.REGULAR
+    assert teddy_bear_infantry.experience == UnitEnums.Experience.REGULAR
     teddy_bear_infantry.level_up()
     # assert stats were changed by level up correctly
     # magic numbers provided by table from MCDM K&W page 99
@@ -26,41 +26,41 @@ def test_infantry_level_up():
     assert teddy_bear_infantry.defense == 12
     assert teddy_bear_infantry.morale == 2
     assert teddy_bear_infantry.command == 1
-    assert teddy_bear_infantry.experience == Unit.Experience.VETERAN
+    assert teddy_bear_infantry.experience == UnitEnums.Experience.VETERAN
     teddy_bear_infantry.level_up()
     assert teddy_bear_infantry.attacks == 2
     assert teddy_bear_infantry.attack == 2
     assert teddy_bear_infantry.defense == 14
     assert teddy_bear_infantry.morale == 4
     assert teddy_bear_infantry.command == 1
-    assert teddy_bear_infantry.experience == Unit.Experience.ELITE
+    assert teddy_bear_infantry.experience == UnitEnums.Experience.ELITE
     teddy_bear_infantry.level_up()
     assert teddy_bear_infantry.attacks == 2
     assert teddy_bear_infantry.attack == 3
     assert teddy_bear_infantry.defense == 16
     assert teddy_bear_infantry.morale == 6
     assert teddy_bear_infantry.command == 2
-    assert teddy_bear_infantry.experience == Unit.Experience.SUPER_ELITE
+    assert teddy_bear_infantry.experience == UnitEnums.Experience.SUPER_ELITE
 
 
 def test_infantry_upgrade():
-    test_infantry = Infantry("Test", "Armed with personality tests.")
+    test_infantry = Unit("Test", UnitEnums.Type.INFANTRY, "Armed with personality tests.")
     test_infantry.power = 0
     test_infantry.toughness = 10
     test_infantry.damage = 1
-    assert test_infantry.equipment == Unit.Equipment.LIGHT
+    assert test_infantry.equipment == UnitEnums.Equipment.LIGHT
     test_infantry.upgrade()
-    assert test_infantry.equipment == Unit.Equipment.MEDIUM
+    assert test_infantry.equipment == UnitEnums.Equipment.MEDIUM
     assert test_infantry.power == 2
     assert test_infantry.toughness == 12
     assert test_infantry.damage == 1
     test_infantry.upgrade()
-    assert test_infantry.equipment == Unit.Equipment.HEAVY
+    assert test_infantry.equipment == UnitEnums.Equipment.HEAVY
     assert test_infantry.power == 4
     assert test_infantry.toughness == 14
     assert test_infantry.damage == 1
     test_infantry.upgrade()
-    assert test_infantry.equipment == Unit.Equipment.SUPER_HEAVY
+    assert test_infantry.equipment == UnitEnums.Equipment.SUPER_HEAVY
     assert test_infantry.power == 6
     assert test_infantry.toughness == 16
     assert test_infantry.damage == 2

--- a/test/test_infantry_unit_class.py
+++ b/test/test_infantry_unit_class.py
@@ -1,18 +1,19 @@
 import pytest
 
+from ..KingdomsAndWarfare.Units.Infantry import Infantry
 from ..KingdomsAndWarfare.Units.Unit import Unit
 from ..KingdomsAndWarfare.Units import UnitEnums
 
 
 def test_infantry():
-    splonks_infantry = Unit("splonks_infantry Infantry", UnitEnums.Type.INFANTRY, "splonks_infantry with butterknives")
+    splonks_infantry = Unit("splonks_infantry Infantry", Infantry, "splonks_infantry with butterknives")
     assert splonks_infantry.name == "splonks_infantry Infantry"
     assert splonks_infantry.experience == UnitEnums.Experience.REGULAR
-    assert splonks_infantry.unit_type == UnitEnums.Type.INFANTRY
+    assert splonks_infantry.unit_type == Infantry
 
 
 def test_infantry_level_up():
-    teddy_bear_infantry = Unit("Teddy Bear Infantry", UnitEnums.Type.INFANTRY, "Teddy Bears with Toy Swords")
+    teddy_bear_infantry = Unit("Teddy Bear Infantry", Infantry, "Teddy Bears with Toy Swords")
     teddy_bear_infantry.attack = 0
     teddy_bear_infantry.defense = 10
     teddy_bear_infantry.morale = 0
@@ -44,7 +45,7 @@ def test_infantry_level_up():
 
 
 def test_infantry_upgrade():
-    test_infantry = Unit("Test", UnitEnums.Type.INFANTRY, "Armed with personality tests.")
+    test_infantry = Unit("Test", Infantry, "Armed with personality tests.")
     test_infantry.power = 0
     test_infantry.toughness = 10
     test_infantry.damage = 1

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -14,6 +14,7 @@ from ..KingdomsAndWarfare.Units.UnitFactory import parse_equipment
 from ..KingdomsAndWarfare.Units.UnitFactory import parse_experience
 from ..KingdomsAndWarfare.Units.UnitFactory import parse_type
 from ..KingdomsAndWarfare.Units.UnitFactory import unit_from_dict
+from ..KingdomsAndWarfare.Units import UnitEnums
 
 
 # testing the unit class, not to be confused with unit tests...
@@ -21,7 +22,7 @@ from ..KingdomsAndWarfare.Units.UnitFactory import unit_from_dict
 def test_unit():
     unit_name = "Splonks Infantry"
     unit_description = "Splonks with swords, mostly."
-    splonks = Unit(unit_name, unit_description)
+    splonks = Unit(unit_name, UnitEnums.Type.INFANTRY, unit_description)
 
     assert splonks.name == unit_name
     assert splonks.description == unit_description
@@ -33,142 +34,144 @@ def test_unit():
 
 
 def test_levelup():
-    splonks = Unit("Splonks Infantry", "Splonks with knives.")
+    splonks = Unit("Splonks Infantry", UnitEnums.Type.INFANTRY, "Splonks with knives.")
     assert splonks.battles == 0
-    assert splonks.experience == Unit.Experience.REGULAR
+    assert splonks.experience == UnitEnums.Experience.REGULAR
     splonks.battle()
     assert splonks.battles == 1
-    assert splonks.experience == Unit.Experience.VETERAN
+    assert splonks.experience == UnitEnums.Experience.VETERAN
     splonks.battle()
     splonks.battle()
     splonks.battle()
     assert splonks.battles == 4
-    assert splonks.experience == Unit.Experience.ELITE
+    assert splonks.experience == UnitEnums.Experience.ELITE
     for index in range(4):
         splonks.battle()
     assert splonks.battles == 8
-    assert splonks.experience == Unit.Experience.SUPER_ELITE
+    assert splonks.experience == UnitEnums.Experience.SUPER_ELITE
     with pytest.raises(CannotLevelUpError):
         splonks.level_up()
 
 
 def test_level_up_undo():
     units = [
-        Infantry("Goldfish Infantry", "Goldfish with lightsabers"),
-        Artillery("Gunslingers", "Slingers who throw guns"),
-        Cavalry("Rhino Cavalry", "Rhinos riding very large horses"),
+        Unit("Goldfish Infantry", UnitEnums.Type.INFANTRY, "Goldfish with lightsabers"),
+        Unit("Gunslingers", UnitEnums.Type.ARTILLERY, "Slingers who throw guns"),
+        Unit("Rhino Cavalry", UnitEnums.Type.CAVALRY, "Rhinos riding very large horses"),
     ]
     for unit in units:
-        assert unit.experience == Unit.Experience.REGULAR
+        assert unit.experience == UnitEnums.Experience.REGULAR
         my_clone = deepcopy(unit)
         unit.level_up()
         unit.level_up()
         unit.level_up()
-        assert unit.experience == Unit.Experience.SUPER_ELITE
+        assert unit.experience == UnitEnums.Experience.SUPER_ELITE
         unit.level_down()
         unit.level_down()
         unit.level_down()
-        assert unit.experience == Unit.Experience.REGULAR
+        assert unit.experience == UnitEnums.Experience.REGULAR
         assert my_clone == unit
 
 
 def test_level_up_undo():
     units = [
-        Infantry("Goldfish Infantry", "Goldfish with lightsabers"),
-        Artillery("Gunslingers", "Slingers who throw guns"),
-        Cavalry("Rhino Cavalry", "Rhinos riding very large horses"),
+        Unit("Goldfish Infantry", UnitEnums.Type.INFANTRY, "Goldfish with lightsabers"),
+        Unit("Gunslingers", UnitEnums.Type.ARTILLERY, "Slingers who throw guns"),
+        Unit("Rhino Cavalry", UnitEnums.Type.CAVALRY, "Rhinos riding very large horses"),
     ]
     for unit in units:
-        assert unit.experience == Unit.Experience.REGULAR
+        assert unit.experience == UnitEnums.Experience.REGULAR
         my_clone = deepcopy(unit)
         unit.level_up()
         unit.level_up()
         unit.level_up()
-        assert unit.experience == Unit.Experience.SUPER_ELITE
+        assert unit.experience == UnitEnums.Experience.SUPER_ELITE
         unit.level_down()
         unit.level_down()
         unit.level_down()
-        assert unit.experience == Unit.Experience.REGULAR
+        assert unit.experience == UnitEnums.Experience.REGULAR
         assert my_clone == unit
 
 
 def test_levelup_levies():
-    splonks = Unit("Splonks levies", "Splonk levies use pumpkins as balaclavas.")
-    splonks.experience = Unit.Experience.LEVIES
+    splonks = Unit("Splonks levies", UnitEnums.Type.INFANTRY, "Splonk levies use pumpkins as balaclavas.")
+    splonks.experience = UnitEnums.Experience.LEVIES
     with pytest.raises(CannotLevelUpError):
         splonks.level_up()
 
 
 def test_upgrade_infantry():
-    infantry = Unit("Splonks Infantry", "Splonkitude")
-    assert infantry.equipment == Unit.Equipment.LIGHT
+    infantry = Unit("Splonks Infantry", UnitEnums.Type.INFANTRY, "Splonkitude")
+    assert infantry.equipment == UnitEnums.Equipment.LIGHT
     infantry.upgrade()
-    assert infantry.equipment == Unit.Equipment.MEDIUM
+    assert infantry.equipment == UnitEnums.Equipment.MEDIUM
     infantry.upgrade()
-    assert infantry.equipment == Unit.Equipment.HEAVY
+    assert infantry.equipment == UnitEnums.Equipment.HEAVY
     infantry.upgrade()
-    assert infantry.equipment == Unit.Equipment.SUPER_HEAVY
+    assert infantry.equipment == UnitEnums.Equipment.SUPER_HEAVY
     with pytest.raises(CannotUpgradeError):
         infantry.upgrade()
 
 
 def test_upgrade_undo():
     units = [
-        Infantry("Creepy Puppets", "Puppets on magical strings."),
-        Artillery("Fish People", "Fish people with squirtguns."),
-        Cavalry("Sand People", "Riding Speeder bikes."),
+        Unit("Creepy Puppets", UnitEnums.Type.INFANTRY, "Puppets on magical strings."),
+        Unit("Fish People", UnitEnums.Type.ARTILLERY, "Fish people with squirtguns."),
+        Unit("Sand People", UnitEnums.Type.CAVALRY, "Riding Speeder bikes."),
     ]
     for unit in units:
         my_clone = deepcopy(unit)
-        assert unit.equipment == Unit.Equipment.LIGHT
+        assert unit.equipment == UnitEnums.Equipment.LIGHT
         unit.upgrade()
         unit.upgrade()
         unit.upgrade()
-        assert unit.equipment == Unit.Equipment.SUPER_HEAVY
+        assert unit.equipment == UnitEnums.Equipment.SUPER_HEAVY
         unit.downgrade()
         unit.downgrade()
         unit.downgrade()
-        assert unit.equipment == Unit.Equipment.LIGHT
+        assert unit.equipment == UnitEnums.Equipment.LIGHT
         assert unit == my_clone
 
 
 def test_upgrade_undo():
     units = [
-        Infantry("Creepy Puppets", "Puppets on magical strings."),
-        Artillery("Fish People", "Fish people with squirtguns."),
-        Cavalry("Sand People", "Riding Speeder bikes."),
+        Unit("Creepy Puppets", UnitEnums.Type.INFANTRY, "Puppets on magical strings."),
+        Unit("Fish People", UnitEnums.Type.ARTILLERY, "Fish people with squirtguns."),
+        Unit("Sand People", UnitEnums.Type.CAVALRY, "Riding Speeder bikes."),
     ]
     for unit in units:
         my_clone = deepcopy(unit)
-        assert unit.equipment == Unit.Equipment.LIGHT
+        assert unit.equipment == UnitEnums.Equipment.LIGHT
         unit.upgrade()
         unit.upgrade()
         unit.upgrade()
-        assert unit.equipment == Unit.Equipment.SUPER_HEAVY
+        assert unit.equipment == UnitEnums.Equipment.SUPER_HEAVY
         unit.downgrade()
         unit.downgrade()
         unit.downgrade()
-        assert unit.equipment == Unit.Equipment.LIGHT
+        assert unit.equipment == UnitEnums.Equipment.LIGHT
         assert unit == my_clone
 
 
 def test_upgrade_levies():
-    levies = Unit("Splonks Levies", "Cucumbers")
-    levies.experience = Unit.Experience.LEVIES
+    levies = Unit("Splonks Levies", UnitEnums.Type.INFANTRY, "Cucumbers")
+    levies.experience = UnitEnums.Experience.LEVIES
     with pytest.raises(CannotUpgradeError):
         levies.upgrade()
 
 
 def test_typical_use():
-    catapult = Infantry("Catapult", "Cats with heavy pulitzer prize trophies.")
+    catapult = Unit("Catapult", UnitEnums.Type.INFANTRY, "Cats with heavy pulitzer prize trophies.")
     seige_weapon = Trait("Seige Weapon", "These cats will lay seige until given pets.")
     assert catapult.attacks == 1
     assert catapult.attack == 0
     assert catapult.defense == 10
+    assert catapult.power == 0
+    assert catapult.toughness == 10
     assert catapult.morale == 0
     assert catapult.command == 0
-    assert catapult.experience == Unit.Experience.REGULAR
-    assert catapult.equipment == Unit.Equipment.LIGHT
+    assert catapult.experience == UnitEnums.Experience.REGULAR
+    assert catapult.equipment == UnitEnums.Equipment.LIGHT
     catapult.add_trait(seige_weapon)
     clone = deepcopy(catapult)
     catapult.upgrade()
@@ -176,23 +179,31 @@ def test_typical_use():
     assert catapult.attacks == 1
     assert catapult.attack == 1
     assert catapult.defense == 12
+    assert catapult.power == 2
+    assert catapult.toughness == 12
+    assert catapult.morale == 2
     assert catapult.command == 1
-    assert catapult.experience == Unit.Experience.VETERAN
-    assert catapult.equipment == Unit.Equipment.MEDIUM
+    assert catapult.experience == UnitEnums.Experience.VETERAN
+    assert catapult.equipment == UnitEnums.Equipment.MEDIUM
     saved = catapult.to_dict()
     loaded = unit_from_dict(saved)
     assert loaded.attacks == 1
     assert loaded.attack == 1
     assert loaded.defense == 12
+    assert loaded.power == 2
+    assert loaded.toughness == 12
+    assert loaded.morale == 2
     assert loaded.command == 1
-    assert loaded.experience == Unit.Experience.VETERAN
-    assert loaded.equipment == Unit.Equipment.MEDIUM
+    assert loaded.experience == UnitEnums.Experience.VETERAN
+    assert loaded.equipment == UnitEnums.Equipment.MEDIUM
     loaded.upgrade()
     loaded.level_up()
     # infantry leveled up twice to elite, heavy
     assert loaded.attacks == 2
     assert loaded.attack == 2
     assert loaded.defense == 14
+    assert loaded.power == 4
+    assert loaded.toughness == 14
     assert loaded.morale == 4
     assert loaded.command == 1
     loaded.level_down()
@@ -203,48 +214,48 @@ def test_typical_use():
 
 
 def test_parse_type():
-    assert parse_type("infantry") == Unit.Type.INFANTRY
-    assert parse_type("cavalry") == Unit.Type.CAVALRY
-    assert parse_type("artillery") == Unit.Type.ARTILLERY
-    assert parse_type("aerial") == Unit.Type.AERIAL
-    assert parse_type("TYPE.INFANTRY") == Unit.Type.INFANTRY
-    assert parse_type("TYPE.CAVALRY") == Unit.Type.CAVALRY
-    assert parse_type("TYPE.ARTILLERY") == Unit.Type.ARTILLERY
-    assert parse_type("TYPE.AERIAL") == Unit.Type.AERIAL
-    assert parse_type("1") == Unit.Type.INFANTRY
-    assert parse_type("2") == Unit.Type.ARTILLERY
-    assert parse_type("3") == Unit.Type.CAVALRY
-    assert parse_type("4") == Unit.Type.AERIAL
+    assert parse_type("infantry") == UnitEnums.Type.INFANTRY
+    assert parse_type("cavalry") == UnitEnums.Type.CAVALRY
+    assert parse_type("artillery") == UnitEnums.Type.ARTILLERY
+    assert parse_type("aerial") == UnitEnums.Type.AERIAL
+    assert parse_type("TYPE.INFANTRY") == UnitEnums.Type.INFANTRY
+    assert parse_type("TYPE.CAVALRY") == UnitEnums.Type.CAVALRY
+    assert parse_type("TYPE.ARTILLERY") == UnitEnums.Type.ARTILLERY
+    assert parse_type("TYPE.AERIAL") == UnitEnums.Type.AERIAL
+    assert parse_type("1") == UnitEnums.Type.INFANTRY
+    assert parse_type("2") == UnitEnums.Type.ARTILLERY
+    assert parse_type("3") == UnitEnums.Type.CAVALRY
+    assert parse_type("4") == UnitEnums.Type.AERIAL
 
 
 def test_parse_equipment():
-    assert parse_equipment("light") == Unit.Equipment.LIGHT
-    assert parse_equipment("medium") == Unit.Equipment.MEDIUM
-    assert parse_equipment("heavy") == Unit.Equipment.HEAVY
-    assert parse_equipment("super_heavy") == Unit.Equipment.SUPER_HEAVY
-    assert parse_equipment("EQUIPMENT.LIGHT") == Unit.Equipment.LIGHT
-    assert parse_equipment("EQUIPMENT.MEDIUM") == Unit.Equipment.MEDIUM
-    assert parse_equipment("EQUIPMENT.HEAVY") == Unit.Equipment.HEAVY
-    assert parse_equipment("EQUIPMENT.SUPER_HEAVY") == Unit.Equipment.SUPER_HEAVY
-    assert parse_equipment("1") == Unit.Equipment.LIGHT
-    assert parse_equipment("2") == Unit.Equipment.MEDIUM
-    assert parse_equipment("3") == Unit.Equipment.HEAVY
-    assert parse_equipment("4") == Unit.Equipment.SUPER_HEAVY
+    assert parse_equipment("light") == UnitEnums.Equipment.LIGHT
+    assert parse_equipment("medium") == UnitEnums.Equipment.MEDIUM
+    assert parse_equipment("heavy") == UnitEnums.Equipment.HEAVY
+    assert parse_equipment("super_heavy") == UnitEnums.Equipment.SUPER_HEAVY
+    assert parse_equipment("EQUIPMENT.LIGHT") == UnitEnums.Equipment.LIGHT
+    assert parse_equipment("EQUIPMENT.MEDIUM") == UnitEnums.Equipment.MEDIUM
+    assert parse_equipment("EQUIPMENT.HEAVY") == UnitEnums.Equipment.HEAVY
+    assert parse_equipment("EQUIPMENT.SUPER_HEAVY") == UnitEnums.Equipment.SUPER_HEAVY
+    assert parse_equipment("1") == UnitEnums.Equipment.LIGHT
+    assert parse_equipment("2") == UnitEnums.Equipment.MEDIUM
+    assert parse_equipment("3") == UnitEnums.Equipment.HEAVY
+    assert parse_equipment("4") == UnitEnums.Equipment.SUPER_HEAVY
 
 
 def test_parse_experience():
-    assert parse_experience("regular") == Unit.Experience.REGULAR
-    assert parse_experience("veteran") == Unit.Experience.VETERAN
-    assert parse_experience("elite") == Unit.Experience.ELITE
-    assert parse_experience("super_elite") == Unit.Experience.SUPER_ELITE
-    assert parse_experience("levies") == Unit.Experience.LEVIES
-    assert parse_experience("EXPERIENCE.REGULAR") == Unit.Experience.REGULAR
-    assert parse_experience("EXPERIENCE.VETERAN") == Unit.Experience.VETERAN
-    assert parse_experience("EXPERIENCE.ELITE") == Unit.Experience.ELITE
-    assert parse_experience("EXPERIENCE.SUPER_ELITE") == Unit.Experience.SUPER_ELITE
-    assert parse_experience("EXPERIENCE.LEVIES") == Unit.Experience.LEVIES
-    assert parse_experience("1") == Unit.Experience.LEVIES
-    assert parse_experience("2") == Unit.Experience.REGULAR
-    assert parse_experience("3") == Unit.Experience.VETERAN
-    assert parse_experience("4") == Unit.Experience.ELITE
-    assert parse_experience("5") == Unit.Experience.SUPER_ELITE
+    assert parse_experience("regular") == UnitEnums.Experience.REGULAR
+    assert parse_experience("veteran") == UnitEnums.Experience.VETERAN
+    assert parse_experience("elite") == UnitEnums.Experience.ELITE
+    assert parse_experience("super_elite") == UnitEnums.Experience.SUPER_ELITE
+    assert parse_experience("levies") == UnitEnums.Experience.LEVIES
+    assert parse_experience("EXPERIENCE.REGULAR") == UnitEnums.Experience.REGULAR
+    assert parse_experience("EXPERIENCE.VETERAN") == UnitEnums.Experience.VETERAN
+    assert parse_experience("EXPERIENCE.ELITE") == UnitEnums.Experience.ELITE
+    assert parse_experience("EXPERIENCE.SUPER_ELITE") == UnitEnums.Experience.SUPER_ELITE
+    assert parse_experience("EXPERIENCE.LEVIES") == UnitEnums.Experience.LEVIES
+    assert parse_experience("1") == UnitEnums.Experience.LEVIES
+    assert parse_experience("2") == UnitEnums.Experience.REGULAR
+    assert parse_experience("3") == UnitEnums.Experience.VETERAN
+    assert parse_experience("4") == UnitEnums.Experience.ELITE
+    assert parse_experience("5") == UnitEnums.Experience.SUPER_ELITE

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -5,6 +5,7 @@ import pytest
 
 from ..KingdomsAndWarfare.Traits.Trait import Trait
 from ..KingdomsAndWarfare.Units.Artillery import Artillery
+from ..KingdomsAndWarfare.Units.Aerial import Aerial
 from ..KingdomsAndWarfare.Units.Cavalry import Cavalry
 from ..KingdomsAndWarfare.Units.Infantry import Infantry
 from ..KingdomsAndWarfare.Units.Unit import CannotLevelUpError
@@ -22,7 +23,7 @@ from ..KingdomsAndWarfare.Units import UnitEnums
 def test_unit():
     unit_name = "Splonks Infantry"
     unit_description = "Splonks with swords, mostly."
-    splonks = Unit(unit_name, UnitEnums.Type.INFANTRY, unit_description)
+    splonks = Unit(unit_name, Infantry, unit_description)
 
     assert splonks.name == unit_name
     assert splonks.description == unit_description
@@ -34,7 +35,7 @@ def test_unit():
 
 
 def test_levelup():
-    splonks = Unit("Splonks Infantry", UnitEnums.Type.INFANTRY, "Splonks with knives.")
+    splonks = Unit("Splonks Infantry", Infantry, "Splonks with knives.")
     assert splonks.battles == 0
     assert splonks.experience == UnitEnums.Experience.REGULAR
     splonks.battle()
@@ -55,9 +56,9 @@ def test_levelup():
 
 def test_level_up_undo():
     units = [
-        Unit("Goldfish Infantry", UnitEnums.Type.INFANTRY, "Goldfish with lightsabers"),
-        Unit("Gunslingers", UnitEnums.Type.ARTILLERY, "Slingers who throw guns"),
-        Unit("Rhino Cavalry", UnitEnums.Type.CAVALRY, "Rhinos riding very large horses"),
+        Unit("Goldfish Infantry", Infantry, "Goldfish with lightsabers"),
+        Unit("Gunslingers", Artillery, "Slingers who throw guns"),
+        Unit("Rhino Cavalry", Cavalry, "Rhinos riding very large horses"),
     ]
     for unit in units:
         assert unit.experience == UnitEnums.Experience.REGULAR
@@ -75,9 +76,9 @@ def test_level_up_undo():
 
 def test_level_up_undo():
     units = [
-        Unit("Goldfish Infantry", UnitEnums.Type.INFANTRY, "Goldfish with lightsabers"),
-        Unit("Gunslingers", UnitEnums.Type.ARTILLERY, "Slingers who throw guns"),
-        Unit("Rhino Cavalry", UnitEnums.Type.CAVALRY, "Rhinos riding very large horses"),
+        Unit("Goldfish Infantry", Infantry, "Goldfish with lightsabers"),
+        Unit("Gunslingers", Artillery, "Slingers who throw guns"),
+        Unit("Rhino Cavalry", Cavalry, "Rhinos riding very large horses"),
     ]
     for unit in units:
         assert unit.experience == UnitEnums.Experience.REGULAR
@@ -94,14 +95,14 @@ def test_level_up_undo():
 
 
 def test_levelup_levies():
-    splonks = Unit("Splonks levies", UnitEnums.Type.INFANTRY, "Splonk levies use pumpkins as balaclavas.")
+    splonks = Unit("Splonks levies", Infantry, "Splonk levies use pumpkins as balaclavas.")
     splonks.experience = UnitEnums.Experience.LEVIES
     with pytest.raises(CannotLevelUpError):
         splonks.level_up()
 
 
 def test_upgrade_infantry():
-    infantry = Unit("Splonks Infantry", UnitEnums.Type.INFANTRY, "Splonkitude")
+    infantry = Unit("Splonks Infantry", Infantry, "Splonkitude")
     assert infantry.equipment == UnitEnums.Equipment.LIGHT
     infantry.upgrade()
     assert infantry.equipment == UnitEnums.Equipment.MEDIUM
@@ -115,9 +116,9 @@ def test_upgrade_infantry():
 
 def test_upgrade_undo():
     units = [
-        Unit("Creepy Puppets", UnitEnums.Type.INFANTRY, "Puppets on magical strings."),
-        Unit("Fish People", UnitEnums.Type.ARTILLERY, "Fish people with squirtguns."),
-        Unit("Sand People", UnitEnums.Type.CAVALRY, "Riding Speeder bikes."),
+        Unit("Creepy Puppets", Infantry, "Puppets on magical strings."),
+        Unit("Fish People", Artillery, "Fish people with squirtguns."),
+        Unit("Sand People", Cavalry, "Riding Speeder bikes."),
     ]
     for unit in units:
         my_clone = deepcopy(unit)
@@ -135,9 +136,9 @@ def test_upgrade_undo():
 
 def test_upgrade_undo():
     units = [
-        Unit("Creepy Puppets", UnitEnums.Type.INFANTRY, "Puppets on magical strings."),
-        Unit("Fish People", UnitEnums.Type.ARTILLERY, "Fish people with squirtguns."),
-        Unit("Sand People", UnitEnums.Type.CAVALRY, "Riding Speeder bikes."),
+        Unit("Creepy Puppets", Infantry, "Puppets on magical strings."),
+        Unit("Fish People", Artillery, "Fish people with squirtguns."),
+        Unit("Sand People", Cavalry, "Riding Speeder bikes."),
     ]
     for unit in units:
         my_clone = deepcopy(unit)
@@ -154,14 +155,14 @@ def test_upgrade_undo():
 
 
 def test_upgrade_levies():
-    levies = Unit("Splonks Levies", UnitEnums.Type.INFANTRY, "Cucumbers")
+    levies = Unit("Splonks Levies", Infantry, "Cucumbers")
     levies.experience = UnitEnums.Experience.LEVIES
     with pytest.raises(CannotUpgradeError):
         levies.upgrade()
 
 
 def test_typical_use():
-    catapult = Unit("Catapult", UnitEnums.Type.INFANTRY, "Cats with heavy pulitzer prize trophies.")
+    catapult = Unit("Catapult", Infantry, "Cats with heavy pulitzer prize trophies.")
     seige_weapon = Trait("Seige Weapon", "These cats will lay seige until given pets.")
     assert catapult.attacks == 1
     assert catapult.attack == 0
@@ -214,18 +215,10 @@ def test_typical_use():
 
 
 def test_parse_type():
-    assert parse_type("infantry") == UnitEnums.Type.INFANTRY
-    assert parse_type("cavalry") == UnitEnums.Type.CAVALRY
-    assert parse_type("artillery") == UnitEnums.Type.ARTILLERY
-    assert parse_type("aerial") == UnitEnums.Type.AERIAL
-    assert parse_type("TYPE.INFANTRY") == UnitEnums.Type.INFANTRY
-    assert parse_type("TYPE.CAVALRY") == UnitEnums.Type.CAVALRY
-    assert parse_type("TYPE.ARTILLERY") == UnitEnums.Type.ARTILLERY
-    assert parse_type("TYPE.AERIAL") == UnitEnums.Type.AERIAL
-    assert parse_type("1") == UnitEnums.Type.INFANTRY
-    assert parse_type("2") == UnitEnums.Type.ARTILLERY
-    assert parse_type("3") == UnitEnums.Type.CAVALRY
-    assert parse_type("4") == UnitEnums.Type.AERIAL
+    assert parse_type(Infantry.__qualname__) == Infantry
+    assert parse_type(Cavalry.__qualname__) == Cavalry
+    assert parse_type(Artillery.__qualname__) == Artillery
+    assert parse_type(Aerial.__qualname__) == Aerial
 
 
 def test_parse_equipment():


### PR DESCRIPTION
The important diff is all in the second commit. The first is a dupe from the last PR and I'm not sure why git isn't detecting that.

Infantry, Artillery, etc subclasses have been repurposed as subclasses of UnitType, an abstract class that
specifies the levelup/down and up/downgrade method signatures.

The Unit constructor now requires a unit_type argument, and expects one of the values of UnitEnums.Type
--speaking of, the enums had to be moved out of Unit.py into a new file to avoid circular imports. This is a large contributor to the diff.

In Unit, based on the type enum supplied at construction, it assigns itself one of the four UnitType classes.
Then, when the unit would upgrade or level, it calls the relevant static method of that class to modify its relevant stats.
These methods now return tupled values rather than directly modifying the unit's fields, for reduced dependency weirdness

in the test files, almost all changes are related to the new location of the Enums or the new format of unit construction
(i.e. using Unit() rather than Infantry() and including a type enum argument)
However in test_unit.test_typical_use I did add some missing stat values to the assertions (see lines 163-213)